### PR TITLE
Fix problemset PDF of DAPC 2021

### DIFF
--- a/static/archive/2021/dapc/problemset.pdf
+++ b/static/archive/2021/dapc/problemset.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a920e76f085b3bc11d7f48e5b13d08e9d0a296ac52eda5f792edc2dd791d4acc
-size 4360639
+oid sha256:208609d37b18a024b64de7f50ce22d4ef89b75bf469b92572cf89e2bec3911c3
+size 2868033


### PR DESCRIPTION
For some reason, the problem set of DAPC 2020 was stored there :joy: 