### PR TITLE
Canonify all URLs in the input Markdown

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'http://example.org/'
+baseURL = 'https://commissies.ch.tudelft.nl/chipcie'
 languageCode = 'en-gb'
 title = 'CHipCie'
 theme = "ananke"
@@ -7,6 +7,9 @@ copyright = "W.I.S.V. `Christiaan Huygens'"
 SectionPagesMenu = "main"
 Paginate = 5
 enableRobotsTXT = true
+
+RelativeURLs=true
+CanonifyURLs=true
 
 [params]
   favicon = ""


### PR DESCRIPTION
At https://commissies.ch.tudelft.nl/chipcie/, the links that are automatically generated by Hugo (navbar, news posts) properly link to `/chipcie/...`, but "manual" links link to `/...`. This includes any `<a href="...">` that we write ourselves, e.g.: the "contact" link on the homepage, and all archive pages.

To fix this, I've set `CanonifyURLs` and `RelativeURLs` to `true`, as suggested [here](https://discourse.gohugo.io/t/make-home-to-be-subdirectory/4345/7).

Canonify means: update all URLs in the input (`<a href>`).  
Relative means: do not use baseURL for this, but make URLs relative.

The latter is used so that `hugo serve` still works during development.