### PR TITLE
remove relative and canonize urls. Resolves #37.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,9 +8,6 @@ SectionPagesMenu = "main"
 Paginate = 5
 enableRobotsTXT = true
 
-RelativeURLs = true
-CanonifyURLs = true
-
 [markup.goldmark.renderer]
   unsafe = true
 


### PR DESCRIPTION
Remove the canonization and relative urls from the configuration. This fixes #37. I'm not sure why these were in the configuration in the first place. According to the [documentation](https://gohugo.io/content-management/urls/#post-processing), the two are mutual exclusive and not adviced to be used. Both local and in docker image this did keep the site working.