### PR TITLE
content/systems.md: Upgrade Kotlin to 1.7.21, DOMjudge to 8.2.1

### DIFF
--- a/content/systems.md
+++ b/content/systems.md
@@ -79,13 +79,13 @@ The following languages are allowed during the contest:
 - Java
     - Version: 17.0.6
 - Kotlin
-    - Version: 1.6.0
+    - Version: 1.7.21
 
 Note that Python 2 is no longer supported.
 
 ## Compilation of Submissions
 
-During the contest, teams will submit proposed solutions to the contest problems to the Judges using the [DOMjudge](https://www.domjudge.org) contest control system (version 8.2). This can be done through the [web interface](https://www.domjudge.org/docs/manual/8.2/team.html#web-interface), or using the [submit client](https://www.domjudge.org/docs/manual/8.2/team.html#command-line-submit).
+During the contest, teams will submit proposed solutions to the contest problems to the Judges using the [DOMjudge](https://www.domjudge.org) contest control system (version 8.2.1). This can be done through the [web interface](https://www.domjudge.org/docs/manual/8.2/team.html#web-interface), or using the [submit client](https://www.domjudge.org/docs/manual/8.2/team.html#command-line-submit).
 Source files submitted to the Judges will be compiled using the following command line arguments for the respective language:
 
 - C:

--- a/content/systems.md
+++ b/content/systems.md
@@ -69,15 +69,15 @@ The software configuration will consist of the following:
 The following languages are allowed during the contest:
 
 - C
-    - Compiler version: 11.3.0
+    - Compiler version: 11.4.0
     - Standard: gnu17
 - C++
-    - Compiler version: 11.3.0
+    - Compiler version: 11.4.0
     - Standard: gnu++20
 - Python
     - Version: PyPy 7.3.9 (Python 3.8.13)
 - Java
-    - Version: 17.0.6
+    - Version: 17.0.8
 - Kotlin
     - Version: 1.7.21
 


### PR DESCRIPTION
@maartenweyns Can you please double-check the version numbers? Also for the languages other than Kotlin :smile: 

Note that the "8.2" in the links to the team manual should not be changed to "8.2.1" :slightly_smiling_face: 